### PR TITLE
(fix) Update for rust-url's name change.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! Capable of parsing both URL query strings and POST request bodies.
 
 // Use rust-url over soon to be deprecated liburl
-extern crate url = "url_";
+extern crate url;
 extern crate iron;
 extern crate serialize;
 


### PR DESCRIPTION
Both `rust-url` and the old `liburl` now have the package name `url`, but the clash is fine so long as we don't try to use both in the same crate.

Should fix the build.
