### PR TITLE
(fix) Add second lifetime param to Request.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ impl Key for UrlEncodedQuery {
     type Value = QueryMap;
 }
 
-impl<'a> plugin::Plugin<Request<'a>> for UrlEncodedQuery {
+impl<'a, 'b> plugin::Plugin<Request<'a, 'b>> for UrlEncodedQuery {
     type Error = UrlDecodingError;
 
     fn eval(req: &mut Request) -> QueryResult {
@@ -91,7 +91,7 @@ impl<'a> plugin::Plugin<Request<'a>> for UrlEncodedQuery {
     }
 }
 
-impl<'a> plugin::Plugin<Request<'a>> for UrlEncodedBody {
+impl<'a, 'b> plugin::Plugin<Request<'a, 'b>> for UrlEncodedBody {
     type Error = UrlDecodingError;
 
     fn eval(req: &mut Request) -> QueryResult {


### PR DESCRIPTION
Changes in Hyper propagated to Iron making this change necessary.
See iron/iron@942159f017fe6b8fb23cad3736ef4cad0b7f659a for details.

Fixes #48.