### PR TITLE
(doc) Update readme to suggest crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,11 @@ The query string `a=b&a=c` will result in a mapping from `a` to `[b, c]`.
 
 ## Installation
 
-If you're using a `Cargo` to manage dependencies, just add urlencoded to the toml:
+If you're using `Cargo` to manage dependencies, just add urlencoded to `Cargo.toml`:
 
 ```toml
 [dependencies.urlencoded]
-
-git = "https://github.com/iron/urlencoded.git"
+version = "*"
 ```
 
 Otherwise, `cargo build`, and the rlib will be in your `target` directory.


### PR DESCRIPTION
The readme suggests adding the repository link instead of the preferred way of going via crates.io.