### PR TITLE
(cleanup) remove unused compiler features and a failing Clone derive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(core, std_misc)]
 //! URL Encoded Plugin for Iron.
 //!
 //! Parses "url encoded" data from client requests.
@@ -37,13 +36,14 @@ pub struct UrlEncodedBody;
 ///
 /// The second type of error that can occur is that something goes wrong
 /// when parsing the request body.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum UrlDecodingError{
     /// An error parsing the request body
     BodyError(bodyparser::BodyError),
     /// An empty query string, either in body or url query
     EmptyQuery
 }
+
 pub use UrlDecodingError::*;
 
 impl fmt::Display for UrlDecodingError {


### PR DESCRIPTION
Without these changes, it fails to compile on the latest Rust beta.

These were the errors I got:
```
rs:43:15: 43:36 error: the trait `core::clone::Clone` is not implemented for the type `b
odyparser::errors::BodyError` [E0277]
```
Along with the errors regarding the unstable features.

I'm still a Rust noob, so I hope this won't break anything somewhere else. It worked for me.