### PR TITLE
(chore) Update to iron 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ license = "MIT"
 keywords = ["iron", "web", "url", "encoding"]
 
 [dependencies]
-iron = { version = "0.2", default-features = false }
-url = "0.2"
+iron = "0.3"
+url = "0.5"
 plugin = "0.2"
-bodyparser = "0"
-
+bodyparser = { git = "https://github.com/calebmer/body-parser.git" }


### PR DESCRIPTION
In upgrading `iron-test` to support `iron` 0.3, this is a development dependency. If tests are to pass, this must also be updated. However, `urlencoded` also has some dependencies which need to be updated…

## Dependencies
- [x] Merge iron/persistent#52
- [x] Publish updated `persistent` version
- [x] Merge iron/body-parser#69
- [x] Publish updated `body-parser` version