### PR TITLE
Remove final period from error description string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl StdError for UrlDecodingError {
     fn description(&self) -> &str {
         match *self {
             BodyError(ref err) => err.description(),
-            EmptyQuery => "Expected query, found empty string."
+            EmptyQuery => "Expected query, found empty string"
         }
     }
 


### PR DESCRIPTION
Most crates don't include a final period in their error descriptions. This allows dependent crates to control how to punctuate any error message that is shown to the user.
