### PR TITLE
(feat) update bodyparser dependency 0.5 -> 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ keywords = ["iron", "web", "url", "encoding"]
 iron = "0.5"
 url = "1.2"
 plugin = "0.2"
-bodyparser = "0.5"
+bodyparser = "0.6"


### PR DESCRIPTION
Most other parts or iron have been update to bodyparser 0.6 already, using bodyparser 0.5 along with 0.6 results in unnecessarily multiple crate version.