### PR TITLE
(feat) expose urlencoded::parse for downstream unit testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl<'a, 'b> plugin::Plugin<Request<'a, 'b>> for UrlEncodedQuery {
 
     fn eval(req: &mut Request) -> QueryResult {
         match req.url.query() {
-            Some(ref query) => create_param_hashmap(&query),
+            Some(ref query) => parse(&query),
             None => Err(UrlDecodingError::EmptyQuery)
         }
     }
@@ -96,8 +96,12 @@ impl<'a, 'b> plugin::Plugin<Request<'a, 'b>> for UrlEncodedBody {
         req.get::<bodyparser::Raw>()
             .map(|x| x.unwrap_or("".to_string()))
             .map_err(|e| UrlDecodingError::BodyError(e))
-            .and_then(|x| create_param_hashmap(&x))
+            .and_then(|x| parse(&x))
     }
+}
+
+pub fn parse(data: &str) -> QueryResult {
+    create_param_hashmap(data)
 }
 
 /// Parse a urlencoded string into an optional HashMap.

--- a/tests/round_trip.rs
+++ b/tests/round_trip.rs
@@ -1,0 +1,22 @@
+extern crate urlencoded;
+
+use std::collections::HashMap;
+
+#[test]
+fn test_empty_query_round_trip() {
+    let data = "";
+    let answer = urlencoded::parse(data);
+    assert!(answer.is_err());
+}
+
+#[test]
+fn test_query_round_trip() {
+    let data = "band=arctic%20monkeys&band=mumford%20%26%20sons&band=temper trap&color=green";
+    let answer = urlencoded::parse(data).unwrap();
+
+    let mut control = HashMap::new();
+    control.insert("band".to_string(),
+                   vec!["arctic monkeys".to_string(), "mumford & sons".to_string(), "temper trap".to_string()]);
+    control.insert("color".to_string(), vec!["green".to_string()]);
+    assert_eq!(answer, control);
+}


### PR DESCRIPTION
LMK if there's a better option here, but I'm looking for a lighter weight way to ensure I'm doing the same kind of parsing as Iron in some (not e2e) integration tests. 

Unable to just implement `FromStr` here as we don't own the types we return.